### PR TITLE
add spatial_default_extent config option

### DIFF
--- a/ckanext/spatial/helpers.py
+++ b/ckanext/spatial/helpers.py
@@ -23,6 +23,15 @@ def spatial_widget_expands():
     value = p.toolkit.asbool(value)
     return value
 
+def spatial_default_extent():
+    '''Return the value of the ckanext.spatial.default_extent config setting.
+
+    :rtype: text
+
+    '''
+    value = config.get('ckanext.spatial.default_extent')
+    return value
+
 def get_reference_date(date_str):
     '''
         Gets a reference date extra created by the harvesters and formats it

--- a/ckanext/spatial/plugin.py
+++ b/ckanext/spatial/plugin.py
@@ -147,7 +147,8 @@ class SpatialMetadata(p.SingletonPlugin):
                 'get_reference_date' : spatial_helpers.get_reference_date,
                 'get_responsible_party': spatial_helpers.get_responsible_party,
                 'get_common_map_config' : spatial_helpers.get_common_map_config,
-    'spatial_widget_expands': spatial_helpers.spatial_widget_expands,
+                'spatial_widget_expands': spatial_helpers.spatial_widget_expands,
+                'spatial_default_extent': spatial_helpers.spatial_default_extent,
                 }
 
 class SpatialQuery(p.SingletonPlugin):
@@ -157,6 +158,13 @@ class SpatialQuery(p.SingletonPlugin):
     p.implements(p.IConfigurable, inherit=True)
 
     search_backend = None
+
+    def update_config_schema(self, schema):
+
+        schema.update({
+            'ckanext.spatial.default_extent': [ignore_missing]
+        })
+        return schema
 
     def configure(self, config):
 


### PR DESCRIPTION
add spatial_default_extent config option to production.ini. This allows the default extent of the map widget to be set in the config rather then hardcoded into the template.

example: ckanext.spatial.default_extent = [[48.0, -110.0], [60.0, -50.0]]
