### PR TITLE
add distributor digital transfer options to resource-locator paths

### DIFF
--- a/ckanext/spatial/model/harvested_metadata.py
+++ b/ckanext/spatial/model/harvested_metadata.py
@@ -1213,6 +1213,7 @@ class ISODocument(MappedXmlDocument):
                 "gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor/gmd:MD_Distributor/gmd:distributorTransferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource",
                 # 19115-3
                 "mdb:distributionInfo/mrd:MD_Distribution/mrd:transferOptions/mrd:MD_DigitalTransferOptions/mrd:onLine/cit:CI_OnlineResource",
+                "mdb:distributionInfo/mrd:MD_Distribution/mrd:distributor/mrd:MD_Distributor/mrd:distributorTransferOptions/mrd:MD_DigitalTransferOptions/mrd:onLine/cit:CI_OnlineResource"
             ],
             multiplicity="*",
         ),


### PR DESCRIPTION
add distributor digital transfer options to resource-locator paths so that all xml transfer options are captured. This may impact current xml metadata files. Please review your own files and comment on the viability of this change.

fix cioos-siooc/ckan#62