### PR TITLE
create dataset map initial max zoom setting

### DIFF
--- a/ckanext/spatial/helpers.py
+++ b/ckanext/spatial/helpers.py
@@ -94,3 +94,9 @@ def get_common_map_config():
     '''
     namespace = 'ckanext.spatial.common_map.'
     return dict([(k.replace(namespace, ''), v) for k, v in config.iteritems() if k.startswith(namespace)])
+
+def spatial_get_map_initial_max_zoom(pkg):
+    max_zoom = h.get_pkg_dict_extra(pkg, 'spatial_initial_max_zoom') or \
+        pkg.get('spatial_initial_max_zoom') or \
+        config.get('ckanext.spatial.initial_max_zoom', 9)
+    return max_zoom

--- a/ckanext/spatial/plugin.py
+++ b/ckanext/spatial/plugin.py
@@ -149,6 +149,7 @@ class SpatialMetadata(p.SingletonPlugin):
                 'get_common_map_config' : spatial_helpers.get_common_map_config,
                 'spatial_widget_expands': spatial_helpers.spatial_widget_expands,
                 'spatial_default_extent': spatial_helpers.spatial_default_extent,
+                'spatial_get_map_initial_max_zoom': spatial_helpers.spatial_get_map_initial_max_zoom
                 }
 
 class SpatialQuery(p.SingletonPlugin):

--- a/ckanext/spatial/public/js/dataset_map.js
+++ b/ckanext/spatial/public/js/dataset_map.js
@@ -24,6 +24,7 @@ this.ckan.module('dataset-map', function (jQuery, _) {
     initialize: function () {
 
       this.extent = this.el.data('extent');
+      this.maxZoom = this.el.data('max_zoom') || 9;
       // fix bbox when w-long is positive while e-long is negative.
       // assuming coordinate sequence is west to east (left to right)
       if (this.extent.type == 'Polygon'
@@ -74,9 +75,9 @@ this.ckan.module('dataset-map', function (jQuery, _) {
       extentLayer.addTo(map);
 
       if (this.extent.type == 'Point'){
-        map.setView(L.latLng(this.extent.coordinates[1], this.extent.coordinates[0]), 9);
+        map.setView(L.latLng(this.extent.coordinates[1], this.extent.coordinates[0]), this.maxZoom);
       } else {
-        map.fitBounds(extentLayer.getBounds());
+        map.fitBounds(extentLayer.getBounds().pad(0.1), {maxZoom: this.maxZoom});
       }
     }
   }

--- a/ckanext/spatial/templates/spatial/snippets/dataset_map.html
+++ b/ckanext/spatial/templates/spatial/snippets/dataset_map.html
@@ -15,5 +15,5 @@ extent
 
 <section class="dataset-map-section {% if g.ckan_base_version.startswith('2.0') %}dataset-map-section-20x{% endif %}">
   <h3>{{ _('Dataset extent') }}</h3>
-  {% snippet "spatial/snippets/dataset_map_base.html", extent=extent %}
+  {% snippet "spatial/snippets/dataset_map_base.html", extent=extent, max_zoom=max_zoom %}
 </section>

--- a/ckanext/spatial/templates/spatial/snippets/dataset_map_base.html
+++ b/ckanext/spatial/templates/spatial/snippets/dataset_map_base.html
@@ -11,7 +11,7 @@ extent
 #}
 
 {% set map_config = h.get_common_map_config() %}
-<div class="dataset-map" data-module="dataset-map" data-extent="{{ extent }}" data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}" data-module-map_config="{{ h.dump_json(map_config) }}">
+<div class="dataset-map" data-module="dataset-map" data-extent="{{ extent }}" data-max_zoom="{{ max_zoom }}"data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}" data-module-map_config="{{ h.dump_json(map_config) }}">
   <div id="dataset-map-container"></div>
   <div id="dataset-map-attribution">
     {% snippet "spatial/snippets/map_attribution.html", map_config=map_config %}


### PR DESCRIPTION
This pull request adds an optional config setting and dataset extra to set the initial max zoom level of the map on a dataset page. This only affects the initial map display (on load). users are still able to zoom/pan in as they previously could.

The first non-null value of the following list will be used to set the initial max zoom:

1.  spatial_initial_max_zoom from the dataset extras dictionary
2.  spatial_initial_max_zoom from the dataset dictionary
3. ckanext.spatial.initial_max_zoom from the CKAN config file (production.ini)
4. Default: 9

Blocks cioos-siooc/ckanext-cioos_theme#38

Fixes cioos-siooc/ckan#50