### PR TITLE
populate metadata-date with all date types rather then just creation date

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -772,7 +772,8 @@ class SpatialHarvester(HarvesterBase):
                         pass
                     else:
                         for extra in package_dict.get('extras', []):
-                            if extra['key'] == 'harvest_object_id':
+                            if (extra['key'] in
+                                    ['harvest_object_id', 'h_object_id']):
                                 extra['value'] = harvest_object.id
                         if package_dict:
                             package_index = PackageSearchIndex()

--- a/ckanext/spatial/model/harvested_metadata.py
+++ b/ckanext/spatial/model/harvested_metadata.py
@@ -715,12 +715,9 @@ class ISODocument(MappedXmlDocument):
                 "gmd:dateStamp/gco:DateTime/text()",
                 "gmd:dateStamp/gco:Date/text()",
                 # 19115-3
-                "mdb:dateInfo/cit:CI_Date[cit:dateType/cit:CI_DateTypeCode/@codeListValue='creation']/cit:date/gco:Date/text()",
-                "mdb:dateInfo/cit:CI_Date[cit:dateType/cit:CI_DateTypeCode/text()='creation']/cit:date/gco:Date/text()",
-                "mdb:dateInfo/cit:CI_Date[cit:dateType/cit:CI_DateTypeCode/@codeListValue='creation']/cit:date/gco:DateTime/text()",
-                "mdb:dateInfo/cit:CI_Date[cit:dateType/cit:CI_DateTypeCode/text()='creation']/cit:date/gco:DateTime/text()",
+                "mdb:dateInfo/cit:CI_Date/cit:date/gco:Date/text() | mdb:dateInfo/cit:CI_Date/cit:date/gco:DateTime/text()",
             ],
-            multiplicity="1",
+            multiplicity="1..*",
         ),
         ISOElement(
             name="spatial-reference-system",
@@ -1290,6 +1287,7 @@ class ISODocument(MappedXmlDocument):
         self.infer_date_released(values)
         self.infer_date_updated(values)
         self.infer_date_created(values)
+        self.infer_metadata_date(values)
         self.infer_url(values)
         # Todo: Infer resources.
         self.infer_tags(values)
@@ -1463,6 +1461,13 @@ class ISODocument(MappedXmlDocument):
                 dates.sort(reverse=True)
             value = dates[0]
         values['date-updated'] = value
+
+    def infer_metadata_date(self, values):
+        dates = values.get('metadata-date', [])
+        # use last date in list, here we assume latest date is last.
+        if len(dates):
+            dates.sort(reverse=True)
+            values['metadata-date'] = dates[0]
 
     def infer_date_created(self, values):
         value = ''


### PR DESCRIPTION
fix cioos-siooc/ckan#78
fix harvest_object_id being lost during a re-harvest. if a h_object_id exists in the dataset extras it will also be updated with the harvest id during a re-harvest
change metadata-date to capture all dates and use the last one in the list. assumption being that the last is the newest date.