### PR TITLE
Revert "20210812 fix doi citation"

### DIFF
--- a/ckanext/spatial/model/harvested_metadata.py
+++ b/ckanext/spatial/model/harvested_metadata.py
@@ -1511,7 +1511,6 @@ class ISODocument(MappedXmlDocument):
             doi = re.sub(r'^http.*doi\.org/', '', doi, flags=re.IGNORECASE)  # strip https://doi.org/ and the like
             if doi and re.match(r'^10.\d{4,9}\/[-._;()/:A-Z0-9]+$', doi, re.IGNORECASE):
                 value['DOI'] = doi
-
         # TODO: could we have more then one doi?
 
         field = {}
@@ -1522,18 +1521,13 @@ class ISODocument(MappedXmlDocument):
             abstract = field[lang]['abstract']
             field[lang]['abstract'] = abstract.get(lang)
             field[lang]['language'] = lang
-            field[lang]['URL'] = (
-                "https//doi.org/" + value['DOI'] 
-                if value.get('DOI') != None else 
-                url_for(
+            field[lang]['URL'] = url_for(
                 controller='dataset',
                 action='read',
                 id=munge.munge_name(values.get('guid', '')),
                 local=lang,
                 qualified=True
-                )
             )
-           
             field[lang] = json.dumps([field[lang]])
             # the dump converts utf-8 escape sequences to unicode escape
             # sequences so we have to convert back again


### PR DESCRIPTION
Reverts cioos-siooc/ckanext-spatial#22

I'm not sure the problem this is trying to fix actually exists. doi's which are entered correctly under the 'unique-resource-identifier-full' key are added to the citation as doi's, as expected.

![Screen Shot 2022-01-11 at 7 23 35 PM](https://user-images.githubusercontent.com/6304992/149058384-8cd585da-d6f0-4c60-b3c5-fd2e4a558eb1.png)

![Screen Shot 2022-01-11 at 7 23 43 PM](https://user-images.githubusercontent.com/6304992/149058382-b9b6015c-d67d-4910-b48d-ba910935e754.png)


